### PR TITLE
Add aliases for keyboard shortcuts in command

### DIFF
--- a/lib/command.html
+++ b/lib/command.html
@@ -114,17 +114,28 @@
 
   function onKeyDown(event) {
     event.stopPropagation()
-    if (event.keyCode == 38) // up
+    if (this._isUpKey(event))
       this.setSelected(this.get().selectedIndex - 1)
-    else if (event.keyCode == 40) // down
+    else if (this._isDownKey(event))
       this.setSelected(this.get().selectedIndex + 1)
-    else if (event.keyCode == 27) // escape
+    else if (this._isEscapeKey(event))
       store.closeCommand()
     else if (event.keyCode == 13) // enter
       this.takeAction(this.get().selectedIndex)
     else return
     event.preventDefault()
+  }
+  
+  function _isUpKey ({keyCode, key, metaKey, altKey, ctrlKey} = {}) {
+    return keyCode == 38 || (!metaKey && !altKey && ctrlKey && ['p', 'k'].includes(key))
+  }
 
+  function _isDownKey ({keyCode, key, metaKey, altKey, ctrlKey} = {}) {
+    return keyCode == 40 || (!metaKey && !altKey && ctrlKey && ['n', 'j'].includes(key))
+  }
+  
+  function _isEscapeKey ({keyCode, key, metaKey, altKey, ctrlKey} = {}) {
+    return keyCode == 27 || (!metaKey && !altKey && ctrlKey && key == '[')
   }
 
   function takeAction(idx) {


### PR DESCRIPTION
Add handling for:

* up as Ctrl+k or Ctrl+p in addition to `Up`
* down as Ctrl+j or Ctrl+n in addition to `Down`
* `Escape` as Ctrl+[ in addition to `Escape`