### PR TITLE
Bugfix: Clicking on a failed link in Mini throws an error

### DIFF
--- a/lib/client/mini.html
+++ b/lib/client/mini.html
@@ -36,7 +36,7 @@
     {($groupForFocus.error || '')}
     {#if $groupForFocus == expandedGroup}
       {#each $groupForFocus as result}
-        <a href='javascript:void(0)' on:click='$run({focus: result.fullName, batch: null})' class='fail'>{result.fullName}</a>
+        <a href='javascript:void(0)' on:click='$focusTest(result.fullName)' class='fail'>{result.fullName}</a>
       {/each}
     {:elseif $groupForFocus.length > 1}
       <a href='javascript:void(0)' on:click='set({expandedGroup: $groupForFocus})'>{$groupForFocus.length - 1} other tests failed with the same error</a>


### PR DESCRIPTION
Fixes: https://app.asana.com/0/1167195703032857/1167198652425009
The `$run` method did not exist.