### PR TITLE
Usability: display an error message when AWS config is missing

### DIFF
--- a/lib/cli/commands/cloud.js
+++ b/lib/cli/commands/cloud.js
@@ -1,12 +1,29 @@
 const {Command, flags} = require('@oclif/command')
 
+
+
 class CloudCommand extends Command {
+  loadConfig() {
+    require('../../client/index')
+    let awsConfig = Zen.config.aws
+    if (
+      !awsConfig ||
+      !awsConfig.region ||
+      !awsConfig.accessKeyId ||
+      !awsConfig.secretAccessKey ||
+      !awsConfig.assetBucket
+    ) {
+      throw new Error('AWS config is empty. Please make sure that environment variables are set if you are using them.')
+    }
+  }
+
   async run() {
     // TODO: accept a config file
     // const {flags} = this.parse(CloudCommand)
     // flags.config
 
-    require('../../client/index')
+    this.loadConfig()
+
     if (Zen.webpack) {
       await this.buildWebpack()
     }


### PR DESCRIPTION
This commit only adds the check to the `cloud` command. We will need
to run the same check if we wish to run tests on Lambda from the local server.